### PR TITLE
feat: allow clicking on note cards ala twitter

### DIFF
--- a/packages/client/src/components/MkNoteSub.vue
+++ b/packages/client/src/components/MkNoteSub.vue
@@ -1,9 +1,16 @@
 <template>
-<div v-size="{ max: [450] }" class="wrpstxzv" :class="{ children: depth > 1 }">
+<div
+	v-size="{ max: [450] }"
+	class="wrpstxzv"
+	:class="{ children: depth > 1 }"
+	@click.left.stop="onClick"
+	@click.middle.stop="onMiddleClick"
+	@mousedown.middle.prevent
+>
 	<div class="main">
 		<MkAvatar class="avatar" :user="note.user"/>
 		<div class="body">
-			<XNoteHeader class="header" :note="note" :mini="true"/>
+			<XNoteHeader ref="header" class="header" :note="note" :mini="true"/>
 			<div class="body">
 				<p v-if="note.cw != null" class="cw">
 					<Mfm v-if="note.cw != ''" class="text" :text="note.cw" :author="note.user" :i="$i" :custom-emojis="note.emojis" />
@@ -54,12 +61,27 @@ if (props.detail) {
 		replies = res;
 	});
 }
+
+const header = $ref<{anchor?: HTMLAnchorElement}>()
+const anchor = $computed(() => header?.anchor)
+
+const onClick = (ev: MouseEvent) => {
+  if (!window.getSelection()?.toString()) {
+		ev.preventDefault();
+		anchor?.click();
+	}
+};
+const onMiddleClick = (ev: MouseEvent) => {
+  ev.preventDefault();
+  window.open(anchor?.href, "_blank");
+};
 </script>
 
 <style lang="scss" scoped>
 .wrpstxzv {
 	padding: 16px 32px;
 	font-size: 0.9em;
+	cursor: pointer;
 
 	&.max-width_450px {
 		padding: 14px 16px;
@@ -96,7 +118,6 @@ if (props.detail) {
 
 			> .body {
 				> .cw {
-					cursor: default;
 					display: block;
 					margin: 0;
 					padding: 0;

--- a/packages/client/src/components/global/a.vue
+++ b/packages/client/src/components/global/a.vue
@@ -1,11 +1,11 @@
 <template>
-<a :href="to" :class="active ? activeClass : null" @click.prevent="nav" @contextmenu.prevent.stop="onContextmenu">
+<a ref="anchor" :href="to" :class="active ? activeClass : null" @click.prevent.stop="nav" @contextmenu.prevent.stop="onContextmenu">
 	<slot></slot>
 </a>
 </template>
 
 <script lang="ts" setup>
-import { inject } from 'vue';
+import { inject, ref } from 'vue';
 import * as os from '@/os';
 import copyToClipboard from '@/scripts/copy-to-clipboard';
 import { router } from '@/router';
@@ -22,6 +22,9 @@ const props = withDefaults(defineProps<{
 	activeClass: null,
 	behavior: null,
 });
+
+const anchor = ref<HTMLAnchorElement>();
+defineExpose({ anchor });
 
 type Navigate = (path: string, record?: boolean) => void;
 const navHook = inject<null | Navigate>('navHook', null);

--- a/packages/client/src/components/global/avatar.vue
+++ b/packages/client/src/components/global/avatar.vue
@@ -1,5 +1,5 @@
 <template>
-<span v-if="disableLink" v-user-preview="disablePreview ? undefined : user.id" class="eiwwqkts _noSelect" :class="{ cat: user.isCat, square: $store.state.squareAvatars }" :style="{ color }" :title="acct(user)" @click="onClick">
+<span v-if="disableLink" v-user-preview="disablePreview ? undefined : user.id" class="eiwwqkts _noSelect" :class="{ cat: user.isCat, square: $store.state.squareAvatars }" :style="{ color }" :title="acct(user)" @click.stop="onClick">
 	<img class="inner" :src="url" decoding="async"/>
 	<MkUserOnlineIndicator v-if="showIndicator" class="indicator" :user="user"/>
 </span>

--- a/packages/client/src/components/note-header.vue
+++ b/packages/client/src/components/note-header.vue
@@ -6,7 +6,7 @@
 	<div v-if="note.user.isBot" class="is-bot">bot</div>
 	<div class="username"><MkAcct :user="note.user"/></div>
 	<div class="info">
-		<MkA class="created-at" :to="notePage(note)">
+		<MkA ref="link" class="created-at" :to="notePage(note)">
 			<MkTime :time="note.createdAt"/>
 		</MkA>
 		<span v-if="note.visibility !== 'public'" class="visibility">
@@ -20,7 +20,7 @@
 </template>
 
 <script lang="ts" setup>
-import { } from 'vue';
+import { computed } from 'vue';
 import * as misskey from 'misskey-js';
 import { notePage } from '@/filters/note';
 import { userPage } from '@/filters/user';
@@ -29,6 +29,11 @@ defineProps<{
 	note: misskey.entities.Note;
 	pinned?: boolean;
 }>();
+
+const link = $ref<{anchor?: HTMLAnchorElement}>()
+const anchor = computed(() => link?.anchor)
+
+defineExpose({ anchor })
 </script>
 
 <style lang="scss" scoped>

--- a/packages/client/src/components/note-simple.vue
+++ b/packages/client/src/components/note-simple.vue
@@ -1,8 +1,14 @@
 <template>
-<div v-size="{ min: [350, 500] }" class="yohlumlk">
+<div
+	v-size="{ min: [350, 500] }"
+	class="yohlumlk"
+	@click.left.stop="onClick"
+	@click.middle.stop="onMiddleClick"
+	@mousedown.middle.prevent
+>
 	<MkAvatar class="avatar" :user="note.user"/>
 	<div class="main">
-		<XNoteHeader class="header" :note="note" :mini="true"/>
+		<XNoteHeader ref="header" class="header" :note="note" :mini="true"/>
 		<div class="body">
 			<p v-if="note.cw != null" class="cw">
 				<span v-if="note.cw != ''" class="text">{{ note.cw }}</span>
@@ -29,6 +35,20 @@ const props = defineProps<{
 }>();
 
 const showContent = $ref(false);
+
+const header = $ref<{anchor?: HTMLAnchorElement}>()
+const anchor = $computed(() => header?.anchor)
+
+const onClick = (ev: MouseEvent) => {
+  if (!window.getSelection()?.toString()) {
+		ev.preventDefault();
+		anchor?.click();
+	}
+};
+const onMiddleClick = (ev: MouseEvent) => {
+  ev.preventDefault();
+  window.open(anchor?.href, "_blank");
+};
 </script>
 
 <style lang="scss" scoped>
@@ -38,6 +58,7 @@ const showContent = $ref(false);
 	padding: 0;
 	overflow: clip;
 	font-size: 0.95em;
+	cursor: pointer;
 
 	&.min-width_350px {
 		> .avatar {
@@ -75,7 +96,6 @@ const showContent = $ref(false);
 		> .body {
 
 			> .cw {
-				cursor: default;
 				display: block;
 				margin: 0;
 				padding: 0;
@@ -88,7 +108,6 @@ const showContent = $ref(false);
 
 			> .content {
 				> .text {
-					cursor: default;
 					margin: 0;
 					padding: 0;
 				}

--- a/packages/client/src/components/note.vue
+++ b/packages/client/src/components/note.vue
@@ -36,10 +36,17 @@
 			<span v-if="note.localOnly" class="localOnly"><i class="fas fa-biohazard"></i></span>
 		</div>
 	</div>
-	<article class="article" @contextmenu.stop="onContextmenu">
+	
+	<article
+		class="article"
+		@contextmenu.stop="onContextmenu"
+		@click.left="onClick"
+		@click.middle="onMiddleClick"
+		@mousedown.middle.prevent
+	>
 		<MkAvatar class="avatar" :user="appearNote.user"/>
 		<div class="main">
-			<XNoteHeader class="header" :note="appearNote" :mini="true"/>
+			<XNoteHeader ref="header" class="header" :note="appearNote" :mini="true"/>
 			<MkInstanceTicker v-if="showTicker" class="ticker" :instance="appearNote.user.instance"/>
 			<div class="body">
 				<p v-if="appearNote.cw != null" class="cw">
@@ -66,7 +73,7 @@
 					<XPoll v-if="appearNote.poll" ref="pollViewer" :note="appearNote" class="poll"/>
 					<MkUrlPreview v-for="url in urls" :key="url" :url="url" :compact="true" :detail="false" class="url-preview"/>
 					<div v-if="appearNote.renote" class="renote"><XNoteSimple :note="appearNote.renote"/></div>
-					<button v-if="collapsed" class="fade _button" @click="collapsed = false">
+					<button v-if="collapsed" class="fade _button" @click.stop="collapsed = false">
 						<span>{{ i18n.ts.showMore }}</span>
 					</button>
 				</div>
@@ -74,19 +81,19 @@
 			</div>
 			<footer class="footer">
 				<XReactionsViewer ref="reactionsViewer" :note="appearNote"/>
-				<button class="button _button" @click="reply()">
+				<button class="button _button" @click.stop="reply()">
 					<template v-if="appearNote.reply"><i class="fas fa-reply-all"></i></template>
 					<template v-else><i class="fas fa-reply"></i></template>
 					<p v-if="appearNote.repliesCount > 0" class="count">{{ appearNote.repliesCount }}</p>
 				</button>
 				<XRenoteButton ref="renoteButton" class="button" :note="appearNote" :count="appearNote.renoteCount"/>
-				<button v-if="appearNote.myReaction == null" ref="reactButton" class="button _button" @click="react()">
+				<button v-if="appearNote.myReaction == null" ref="reactButton" class="button _button" @click.stop="react()">
 					<i class="fas fa-plus"></i>
 				</button>
-				<button v-if="appearNote.myReaction != null" ref="reactButton" class="button _button reacted" @click="undoReact(appearNote)">
+				<button v-if="appearNote.myReaction != null" ref="reactButton" class="button _button reacted" @click.stop="undoReact(appearNote)">
 					<i class="fas fa-minus"></i>
 				</button>
-				<button ref="menuButton" class="button _button" @click="menu()">
+				<button ref="menuButton" class="button _button" @click.stop="menu()">
 					<i class="fas fa-ellipsis-h"></i>
 				</button>
 			</footer>
@@ -121,6 +128,7 @@ import MkInstanceTicker from '@/components/instance-ticker.vue';
 import { pleaseLogin } from '@/scripts/please-login';
 import { focusPrev, focusNext } from '@/scripts/focus';
 import { checkWordMute } from '@/scripts/check-word-mute';
+import { notePage } from '@/filters/note';
 import { userPage } from '@/filters/user';
 import * as os from '@/os';
 import { defaultStore, noteViewInterruptors } from '@/store';
@@ -176,6 +184,20 @@ const translation = ref(null);
 const translating = ref(false);
 const urls = appearNote.text ? extractUrlFromMfm(mfm.parse(appearNote.text)) : null;
 const showTicker = (defaultStore.state.instanceTicker === 'always') || (defaultStore.state.instanceTicker === 'remote' && appearNote.user.instance);
+
+const header = $ref<{anchor?: HTMLAnchorElement}>()
+const anchor = $computed(() => header?.anchor)
+
+const onClick = (ev: MouseEvent) => {
+  if (!window.getSelection()?.toString()) {
+		ev.preventDefault();
+		anchor?.click();
+	}
+};
+const onMiddleClick = (ev: MouseEvent) => {
+  ev.preventDefault();
+  window.open(anchor?.href, "_blank");
+};
 
 const keymap = {
 	'r': () => reply(true),
@@ -422,6 +444,7 @@ function readPromo() {
 	> .article {
 		display: flex;
 		padding: 28px 32px 18px;
+		cursor: pointer;
 
 		> .avatar {
 			flex-shrink: 0;

--- a/packages/client/src/components/renote-button.vue
+++ b/packages/client/src/components/renote-button.vue
@@ -2,7 +2,7 @@
 <button v-if="canRenote"
 	ref="buttonRef"
 	class="eddddedb _button canRenote"
-	@click="renote()"
+	@click.stop="renote()"
 >
 	<i class="fas fa-retweet"></i>
 	<p v-if="count > 0" class="count">{{ count }}</p>


### PR DESCRIPTION
Adds event handlers to note cards (main in timeline, embedded quote-renotes, and replies/parents) so that clicking them navigates to them, and middle clicking will open them in a new tab, without need to click on the date of the note, ala Twitter.