### PR TITLE
Fix not being able to click content-warning button

### DIFF
--- a/packages/client/src/components/cw-button.vue
+++ b/packages/client/src/components/cw-button.vue
@@ -1,5 +1,5 @@
 <template>
-<button class="nrvgflfu _button" @click="toggle">
+<button class="nrvgflfu _button" @click.stop="toggle">
 	<b>{{ modelValue ? i18n.ts._cw.hide : i18n.ts._cw.show }}</b>
 	<span v-if="!modelValue">{{ label }}</span>
 </button>


### PR DESCRIPTION
Missed another clickable thing in cards, gah.